### PR TITLE
bugfix: using definition of this

### DIFF
--- a/src/runtimes/base.coffee
+++ b/src/runtimes/base.coffee
@@ -2,7 +2,7 @@ platform = require '../platform'
 
 class BaseRuntime extends platform.EventEmitter
   constructor: (@definition) ->
-    @definition.capabilities = [] unless definition.capabilities
+    @definition.capabilities = [] unless @definition.capabilities
     @graph = null
 
   setMain: (@graph) ->


### PR DESCRIPTION
Definition is not defined and will throw an error, as it surely is meant to be the property definition of this.
This resolves https://github.com/noflo/noflo-ui/issues/436.
Currently sometimes projects cannot be opened (at least with Chrom[e|ium]) because of this bug.
Please consider merging this. BR, Jonathan