### PR TITLE
Group components from component:list

### DIFF
--- a/components/ListComponents.coffee
+++ b/components/ListComponents.coffee
@@ -8,9 +8,13 @@ subscribe = (runtime, port) ->
     return unless runtime.canDo 'protocol:component'
     runtime.sendComponent 'list'
     port.connect()
+    port.beginGroup 'list'
 
   onRuntimeConnected = -> do requestListing
   onRuntimeComponent = (message) ->
+    if message.command is 'componentsready'
+      port.endGroup 'list'
+
     return unless message.command is 'component'
     return if message.payload.name in ['Graph', 'ReadDocument']
     definition =


### PR DESCRIPTION
In ListComponents, create a group around initial response from runtime listing components, ending group when ListComponents receives componentsready message.