### PR TITLE
Drop RemoteSubgraph support in browsers unless require-able

### DIFF
--- a/spec/ComponentLoader.coffee
+++ b/spec/ComponentLoader.coffee
@@ -15,9 +15,13 @@ describe 'ComponentLoader', ->
     chai.expect(ComponentLoader).to.be.a 'function'
 
   describe 'runtimes specified in project file', ->
-    baseDir = if noflo.isBrowser() then '/spec/data' else require('path').resolve __dirname, './data/'
+    baseDir = null
+    loader = null
     names = null
-    loader = new noflo.ComponentLoader baseDir
+    before ->
+      return @skip() if noflo.isBrowser()
+      baseDir = require('path').resolve __dirname, './data/'
+      loader = new noflo.ComponentLoader baseDir
     compName = 'runtime/2ef763ff-1f28-49b8-b58f-5c6a5c54af2d'
     it 'should be listed', (done) ->
         @timeout 5000

--- a/src/ComponentLoader.coffee
+++ b/src/ComponentLoader.coffee
@@ -30,14 +30,7 @@ loadBrowserPackage = (baseDir, callback) ->
     packageDef = require packagePath
     callback null, packageDef
   catch e
-    req = new XMLHttpRequest
-    req.onreadystatechange = ->
-      return unless req.readyState is 4
-      unless req.status is 200
-        return callback new Error "Failed to load #{packagePath}: HTTP #{req.status}"
-      callback null, JSON.parse req.responseText
-    req.open 'GET', packagePath, true
-    req.send()
+    callback e
 
 getRuntimesBrowser = (baseDir, callback) ->
   # Read runtime definitions from component.json


### PR DESCRIPTION
Not used anywhere, and causes misleading errors in browser debug console.